### PR TITLE
Complete Exercise 3: Fourier properties

### DIFF
--- a/exercises/E3-Fourier-properties.ipynb
+++ b/exercises/E3-Fourier-properties.ipynb
@@ -89,6 +89,7 @@
     "id": "ZQZwE69Pauxu"
    },
    "source": [
+    "# Function to minimize energy spread in DFT of sinusoids\n",
     "def minimize_energy_spread_dft(x, fs, f1, f2):\n",
     "    \"\"\" From a signal with two sinusoids compute its magnitude spectrum having only two non-zero value.\n",
     "\n",
@@ -102,10 +103,14 @@
     "        np.array: positive half of magnitude spectrum (in dB)\n",
     "\n",
     "    \"\"\"\n",
+    "    # Calculate the periods of the sinusoids\n",
     "    T1 = fs / f1\n",
     "    T2 = fs / f2\n",
+    "    # Calculate the smallest positive integer M for which the positive half of the DFT magnitude spectrum has only two non-zero values\n",
     "    M = int(T1 * T2 / gcd(int(T1), int(T2)))\n",
+    "    # Compute the DFT of the first M samples of the input signal\n",
     "    X = fft(x[:M])\n",
+    "    # Compute the magnitude spectrum of the positive half of the DFT\n",
     "    mX = 20 * np.log10(np.abs(X[:M // 2 + 1]))\n",
     "    return mX"
    ]
@@ -129,6 +134,7 @@
     "id": "BG4EIZGiauxv"
    },
    "source": [
+    "# Test case 1\n",
     "fs = 10000\n",
     "f1 = 80\n",
     "f2 = 200\n",
@@ -141,6 +147,7 @@
     "plt.ylabel('Magnitude (dB)')\n",
     "plt.show()\n",
     "\n",
+    "# Test case 2\n",
     "fs = 48000\n",
     "f1 = 300\n",
     "f2 = 800\n",
@@ -182,6 +189,7 @@
     "id": "WW6d_8Wxauxv"
    },
    "source": [
+    "# Function to check if the input signal is real and even using the symmetry properties of its DFT\n",
     "def test_real_even(x):\n",
     "    \"\"\"check if x is real and even using the symmetry properties of its DFT.\n",
     "    Args:\n",
@@ -194,13 +202,18 @@
     "        X (np.array): M point DFT of dftbuffer\n",
     "\n",
     "    \"\"\"\n",
+    "    # Length of the input signal\n",
     "    M = len(x)\n",
+    "    # Calculate the half sizes of the input signal\n",
     "    hM1 = floor((M + 1) / 2)\n",
     "    hM2 = floor(M / 2)\n",
+    "    # Create the zero phase windowed version of the input signal\n",
     "    dftbuffer = np.zeros(M)\n",
     "    dftbuffer[:hM1] = x[hM2:]\n",
     "    dftbuffer[-hM2:] = x[:hM2]\n",
+    "    # Compute the DFT of the zero phase windowed signal\n",
     "    X = fft(dftbuffer)\n",
+    "    # Check if the input signal is real and even using the symmetry properties of its DFT\n",
     "    isRealEven = np.allclose(X.imag, 0, atol=1e-6)\n",
     "    return isRealEven, dftbuffer, X"
    ]
@@ -236,12 +249,14 @@
     "id": "BdsmJiexauxv"
    },
    "source": [
+    "# Test case 1\n",
     "x = np.array([2, 3, 4, 3, 2])\n",
     "isRealEven, dftbuffer, X = test_real_even(x)\n",
     "print(isRealEven)\n",
     "print(dftbuffer)\n",
     "print(X)\n",
     "\n",
+    "# Test case 2\n",
     "x = get_window('hanning', 51, fftbins=False)\n",
     "isRealEven, dftbuffer, X = test_real_even(x)\n",
     "plt.plot(x)\n",
@@ -290,6 +305,7 @@
     "id": "zmkDACeLauxw"
    },
    "source": [
+    "# Function to suppress frequency components <= 70Hz using the DFT\n",
     "def suppress_freq_dft_model(x, fs, N):\n",
     "    \"\"\"\n",
     "    Args:\n",
@@ -300,12 +316,17 @@
     "    Returns:\n",
     "       np.array: output signal with filtering (N samples long)\n",
     "    \"\"\"\n",
+    "    # Length of the input signal\n",
     "    M = len(x)\n",
+    "    # Use a hamming window to smooth the signal\n",
     "    w = get_window('hamming', M)\n",
     "    outputScaleFactor = sum(w)\n",
+    "    # Obtain the magnitude spectrum (in dB) and phase spectrum of the audio signal\n",
     "    mX, pX = dftAnal(x, w, N)\n",
+    "    # Set the values of the magnitude spectrum that correspond to frequencies <= 70 Hz to -120dB\n",
     "    cutoff_bin = int(np.ceil(70 * N / fs))\n",
     "    mX[:cutoff_bin] = -120\n",
+    "    # Synthesize the filtered output signal\n",
     "    y = dftSynth(mX, pX, M) * outputScaleFactor\n",
     "    return y"
    ]
@@ -331,6 +352,7 @@
     "id": "uBGhXtHtauxw"
    },
    "source": [
+    "# Test case 1\n",
     "fs = 1000\n",
     "N = 1024\n",
     "n = np.arange(0, 1, 1 / fs)\n",
@@ -346,6 +368,7 @@
     "plt.legend()\n",
     "plt.show()\n",
     "\n",
+    "# Test case 2\n",
     "x = np.cos(2 * np.pi * 23 * n) + np.cos(2 * np.pi * 36 * n) + np.cos(2 * np.pi * 230 * n) + np.cos(2 * np.pi * 900 * n) + np.cos(2 * np.pi * 2300 * n)\n",
     "y = suppress_freq_dft_model(x, fs, N)\n",
     "mX, _ = dftAnal(x, get_window('hamming', len(x)), N)\n",
@@ -386,6 +409,7 @@
     "id": "K_pY6Tk7auxw"
    },
    "source": [
+    "# Function to compute magnitude spectra of x with different window sizes and FFT sizes\n",
     "def zp_fft_size_expt(x, window_size=[256, 512, 256], FFT_size=[256, 512, 512]):\n",
     "    \"\"\"compute magnitude spectra of x with different window sizes and FFT sizes.\n",
     "\n",
@@ -397,7 +421,9 @@
     "    \"\"\"\n",
     "    mag_spectra = []\n",
     "    for ws, fs in zip(window_size, FFT_size):\n",
+    "        # Use a hamming window for analysis\n",
     "        w = get_window('hamming', ws)\n",
+    "        # Compute the magnitude spectrum using dftAnal()\n",
     "        mX, _ = dftAnal(x[:ws], w, fs)\n",
     "        mag_spectra.append(mX)\n",
     "    return mag_spectra"
@@ -422,6 +448,7 @@
     "id": "DdRoDRf7auxw"
    },
    "source": [
+    "# Test case 1\n",
     "fs = 1000\n",
     "n = np.arange(512) / fs\n",
     "x = 0.2 * np.cos(2 * np.pi * 200 * n) + 0.2 * np.cos(2 * np.pi * 400 * n)\n",

--- a/exercises/E3-Fourier-properties.ipynb
+++ b/exercises/E3-Fourier-properties.ipynb
@@ -1,1 +1,473 @@
-{"cells":[{"cell_type":"markdown","metadata":{"id":"PPxSP-t3auxr"},"source":["# Exercise 3: Fourier properties\n","\n","With this exercise you will get a better understanding of some of the Fourier theorems and of some useful properties of the DFT. You will write code to implement and verify several properties of the DFT that are discussed in the lectures. You will also learn to use the `dftModel.py` module of sms-tools, which contains the basic python functions implementing the DFT. There are five parts in the exercise: 1) Minimize energy spread in DFT of sinusoids, 2) Symmetry properties of the DFT, 3) Suppressing frequency components using DFT model, and 4) FFT size and zero-padding.\n","\n","### Relevant Concepts\n","\n","__DFT of sinusoids:__ When a real sinusoid has an integer number of cycles in $N$ samples, the frequency of the sinusoid exactly matches one of the bin frequencies in an $N$ point DFT. Hence the DFT spectrum of the sinusoid has a value of zero at every DFT bin except at the two bins that match the frequency of the sinusoid. Otherwise, the energy of the sinusoid is spread over all the bins. When there are multiple sinusoids, the equations extend to each sinusoid.\n","\n","\\begin{align}\n"," x[n]&=&A_{0}\\cos\\left(2\\pi k_{0}n/N\\right)=\\frac{A_{0}}{2}{\\textstyle e}^{j2\\pi k_{0}n/N}+\\frac{A_{0}}{2}{\\textstyle e}^{-j2\\pi k_{0}n/N}\\\\\n"," X[k] &=& \\frac{A_0}{2} \\,\\,\\, \\mathrm{for} \\,\\,\\, k = k_0, -k_0; \\,\\,\\,\\, 0 \\,\\,\\,\\mathrm{otherwise}\n","\\end{align}\n","\n","__Zero-padding:__ Zero-padding a signal is done by adding zeros at the end of the signal. If we perform zero-padding to a signal before computing its DFT, the resulting spectrum will be an interpolated version of the spectrum of the original signal.  In most implementations of the DFT (including the FFT algorithms) when the DFT size is larger than the length of the signal, zero-padding is implicitly done.\n","\n","__Zero phase windowing:__ Zero phase windowing of a frame of a signal puts the centre of the signal at the zero time index for DFT computation. By moving the centre of the frame to zero index by a circular shift, the computed DFT will not have the phase offset which would have otherwise been introduced (recall that a shift of the signal causes the DFT to be multiplied by a complex exponential, which keeps the magnitude spectrum intact but changes the phase spectrum). When used in conjunction with zero-padding, zero phase windowing is also useful for the creation of a frame of length of power of 2 for FFT computation (`fftbuffer`).\n","\n","If the length of the signal $x$ is $M$ and the required DFT size is $N$, the zero phase windowed version of the signal, `dftbuffer`, for DFT computation can be obtained by (works for both even and odd $M$):\n","\n","    hM1 = floor((M+1)/2)\n","    hM2 = floor(M/2)\n","    dftbuffer = zeros(N)\n","    dftbuffer[:hM1] = x[hM2:]\n","    dftbuffer[-hM2:] = x[:hM2]\n","\n","__Real, even and odd signals:__ A signal is real when it does not have any imaginary component, and all sounds are real signals. A signal $x$ is even if $x[n] = x[-n]$, and odd if $x[n] = -x[-n]$. For a signal of length $M$ (and $M$ is odd), in the context of a zero phase windowed signal and its DFT, the signal is even if $x[n] = x[M-n]$ and odd if $x[n] = -x[M-n]$, $1 \\leq n \\leq M-1$. The DFT properties show that for real input signals, the magnitude spectrum is even and the phase spectrum is odd. Furthermore, when the input signal is both real and even, the DFT is real valued, with an even magnitude spectrum and imaginary component equal to zero. In summary, if $x$ is an input signal of length $M$ ($M$ is odd) and $X = \\mathrm{DFT}(x,M)$, then for $1 \\leq k \\leq M-1$\n","\n","If $x$ is real, $\\left|X[k]\\right| = \\left|X[M-k]\\right|$ and $\\boldsymbol{<}\\!X[k] = -\\boldsymbol{<}\\!X[M-k]$\n","\n","If $x$ is real and even, $\\left|X[k]\\right| = \\left|X[M-k]\\right|$ and $\\mathrm{imag}(X[k]) = 0$\n","\n","\n","__Positive half of the DFT spectrum:__ Audio signals are real signals. Due to the symmetry properties of the DFT of a real signal, it is sufficient to store only one half of the magnitude and phase spectra. To save on both storage and computation, we will just store just the half spectrum when possible.\n","\n","From an $N$ point DFT ($N$ even), we can obtain the positive half of the spectrum by considering only the first $(N/2)+1$ samples of the DFT. We can compute the magnitude spectrum of the positive half (in dB) as $m_X = 20\\log_{10}\\left|X[0:(N/2)+1]\\right|$, where $X$ is the DFT of the input.\n","\n","__Filtering:__ Filtering involves selectively suppressing certain frequencies present in the signal. Filtering is often performed in the time domain by the convolution of the input signal with the impulse response of a filter. The same operation can also be done in the DFT domain using the properties of DFT, by multiplying the DFT of the input signal by the DFT of the impulse response of the filter. In this assignment, we will consider a very simple illustrative filter that suppresses some frequency components by setting some DFT coefficients to zero. It is to be noted that the convolution operation here is circular convolution with a period $N$, the size of the DFT.\n","\n","If $x_1[n] \\Leftrightarrow X_1[k]$ and $x_2[n] \\Leftrightarrow X_2[k]$, $x_1[n] * x_2[n] \\Longleftrightarrow X_1[k]\\,X_2[k]$"]},{"cell_type":"markdown","metadata":{"id":"ZYIM_h_sauxt"},"source":["\n","## Part 1 - Minimize energy spread in DFT of sinusoids\n","\n","Given an input signal consisting of two sinusoids, the function `minimize_energy_spread_dft()` should select the first `M` samples from the signal and return the positive half of the DFT magnitude spectrum (in dB), such that it has only two non-zero values.\n","\n","`M` is to be calculated as the smallest positive integer for which the positive half of the DFT magnitude spectrum has only two non-zero values. To get the positive half of the spectrum, first compute the `M` point DFT of the input signal (for this you can use the `fft()` function of `scipy.fftpack`). Consider only the first `(M/2)+1` samples of the DFT, computing the magnitude spectrum of the positive half (in dB) as `mX = 20*log10(abs(X[:M/2+1]))`, where `X` is the DFT of the input signal.\n","\n","The input arguments to this function are the input signal `x` (of length W >= M) consisting of two sinusoids of frequency `f1` and `f2`, the sampling frequency `fs` and the value of frequencies `f1` and `f2`. The function should return the positive half of the magnitude spectrum `mX`. For this question, you can assume the input frequencies `f1` and `f2` to be positive integers and factors of `fs`, and that `M` is even.\n","\n","Due to the precision of the FFT computation, the zero values of the DFT are not zero but very small values < 1e-12 (or -240 dB) in magnitude. For practical purposes, all values with absolute value less than 1e-6 (or -120 dB) can be considered to be zero.\n","\n","HINT: The DFT magnitude spectrum of a sinusoid has only one non-zero value (in the positive half of the DFT spectrum) when its frequency coincides with one of the DFT bin frequencies. This happens when the DFT size (`M` in this question) contains exactly an integer number of periods of the sinusoid. Since the signal in this question consists of two sinusoids, this condition should hold true for each of the sinusoids, so that the DFT magnitude spectrum has only two non-zero values, one per sinusoid.\n","\n","`M` can be computed as the Least Common Multiple (LCM) of the sinusoid periods (in samples). The LCM of two numbers `x`, `y` can be computed as: `x*y/gcd(x,y)`, where gcd denotes the greatest common divisor."]},{"cell_type":"code","execution_count":null,"metadata":{"id":"9oEQLgLNauxu"},"outputs":[],"source":["from scipy.fftpack import fft, fftshift\n","import numpy as np\n","from math import gcd, ceil, floor\n","from smstools.models.dftModel import dftAnal, dftSynth\n","from scipy.signal import get_window\n","import matplotlib.pyplot as plt"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"ZQZwE69Pauxu"},"outputs":[],"source":["# E3 - 1.1: Complete the function minimize_energy_spread_dft()\n","\n","def minimize_energy_spread_dft(x, fs, f1, f2):\n","    \"\"\" From a signal with two sinusoids compute its magnitude spectrum having only two non-zero value.\n","\n","    Args:\n","        x (np.array): input signal\n","        fs (float): sampling frequency in Hz\n","        f1 (float): frequency of first sinusoid component in Hz\n","        f2 (float): frequency of second sinusoid component in Hz\n","\n","    Returns:\n","        np.array: positive half of magnitude spectrum (in dB)\n","\n","    \"\"\"\n","    ### Your code here\n","\n"]},{"cell_type":"markdown","metadata":{"id":"gV9H1iw6auxv"},"source":["Test cases for `minimize_energy_spread_dft()`:\n","\n","_Test case 1:_ For an input signal `x` sampled at `fs = 10000`Hz that consists of sinusoids of frequencies `f1 = 80`Hz and `f2 = 200`Hz, you need to select `M = 250` samples of the signal to meet the required condition. In this case, output `mX` is 126 samples in length and has non-zero values at bin indices 2 and 5 (corresponding to the frequency values of 80 and 200 Hz, respectively). You can create a test signal `x` by generating and adding two sinusoids of the given frequencies.\n","\n","_Test case 2:_ For an input signal `x` sampled at `fs = 48000` Hz that consists of sinusoids of frequencies `f1 = 300`Hz and `f2 = 800`Hz, you need to select `M = 480` samples of the signal to meet the required condition. In this case, output `mX` is 241 samples in length and has non-zero values at bin indices 3 and 8 (corresponding to the frequency values of 300 and 800 Hz, respectively). You can create a test signal `x` by generating and adding two sinusoids of the given frequencies."]},{"cell_type":"code","execution_count":null,"metadata":{"id":"BG4EIZGiauxv"},"outputs":[],"source":["# E3 - 1.2: Compute and plot the two input signals proposed above, call the function minimize_energy_spread_dft(),\n","# and plot the output magnitude spectra\n","\n","### Your code here\n","\n"]},{"cell_type":"markdown","metadata":{"id":"E8dfWb-pauxv"},"source":["## Part 2 - Symmetry properties of the DFT\n","\n","The function `test_real_even()` should check if the input signal is real and even using the symmetry properties of its DFT. The function will return the result of this test, the zero-phase windowed version of the input signal (`dftbuffer`), and its DFT.\n","\n","Given an input signal `x` of length `M`, do a zero phase windowing of `x` without any zero-padding. Then compute the `M` point DFT of the zero phase windowed signal and use the symmetry of the computed DFT to test if the input signal `x` is real and even. Return the result of the test, the `dftbuffer` computed, and the DFT of the `dftbuffer`.\n","\n","The input argument is a signal `x` of length `M`. The output is a tuple with three elements\n","`(isRealEven, dftbuffer, X)`, where `isRealEven` is a boolean variable which is `True` if `x` is real and even, else `False`. `dftbuffer` is the `M` length zero phase windowed version of `x`. `X` is the `M` point DFT of the `dftbuffer`.\n","\n","To make the problem easier, we will use odd length input sequence in this question (`M` is odd).\n","\n","Due to the precision of the FFT computation, the zero values of the DFT are not zero but very small values < 1e-12 in magnitude. For practical purposes, all values with absolute value less than 1e-6 can be considered to be zero. Use an error tolerance of 1e-6 to compare if two floating point arrays are equal.\n","\n","Caveat: Use the imaginary part of the spectrum instead of the phase to check if the input signal is real and even."]},{"cell_type":"code","execution_count":null,"metadata":{"id":"WW6d_8Wxauxv"},"outputs":[],"source":["# E3 - 2.1: Complete the function test_real_even()\n","\n","def test_real_even(x):\n","    \"\"\"check if x is real and even using the symmetry properties of its DFT.\n","    Args:\n","        x (np.array): input signal of length M (M is odd)\n","\n","    Returns:\n","        tuple including:\n","        isRealEven (boolean): True if input x is real and even, and False otherwise\n","        dftbuffer (np.array): M point zero phase windowed version of x\n","        X (np.array): M point DFT of dftbuffer\n","\n","    \"\"\"\n","    ### Your code here\n"]},{"cell_type":"markdown","metadata":{"id":"W7rW2dmHauxv"},"source":["Test cases for `test_real_even()`:\n","\n","_Test case 1:_ If `x = np.array([2, 3, 4, 3, 2])`, which is a real and even signal (after zero phase windowing), the function returns\n","\n","```\n","(True, array([ 4., 3., 2., 2., 3.]), array([14.0000+0.j, 2.6180+0.j,\n","0.3820+0.j, 0.3820+0.j, 2.6180+0.j])) (values are approximate)\n","```\n","\n","_Test case 2:_ If `x = np.array([1, 2, 3, 4, 1, 2, 3])`, which is not an even signal (after zero phase windowing), the function returns\n","\n","```\n","(False,  array([ 4.,  1.,  2.,  3.,  1.,  2.,  3.]), array([ 16.+0.j,\n","2.+0.69j, 2.+3.51j, 2.-1.08j, 2.+1.08j, 2.-3.51j, 2.-0.69j])) (values are approximate)\n","```\n","\n","To get a more realistic example use a longer input signal and plot the real and imaginary parts of the output spectrum `X`. For example, use `x = get_window('hanning', 51, fftbins=False)`, which is real an even, and plot `x`and the real and imaginary part of the spectrum `X`.\n"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"BdsmJiexauxv"},"outputs":[],"source":["# E3 - 2.2: Plot the input signal proposed above (window signal), call the function test_real_even(),\n","# and plot its output spectrum (real and imaginary)\n","\n","### Your code here\n"]},{"cell_type":"markdown","metadata":{"id":"tzReXqw4auxw"},"source":["## Part 3 - Suppressing frequency components using DFT model\n","\n","Given a signal as input, the function `supress_freq_dft_model()` should suppress the frequency components <= 70Hz using the DFT. It should return the filtered signal in the time domain.\n","\n","Use the DFT to implement a very basic form of frequency domain filtering. Use the functions `dftAnal()` and `dftSynth()` provided in the `dftModel.py` module.\n","\n","Use `dftAnal()` to obtain the magnitude spectrum (in dB) and phase spectrum of the audio signal. Set the values of the magnitude spectrum that correspond to frequencies <= 70 Hz to -120dB (there may not be a bin corresponding exactly to 70Hz, choose the nearest bin of equal or higher frequency, e.g., using `np.ceil()`).\n","\n","Use `dftSynth()` to synthesize the filtered output signal. Then return the filtered signal.\n","\n","Use a hamming window to smooth the signal. Hence, do not forget to scale the output signals by the sum of the window values (as done in `software/models_interface/dftModel_function.py`).  \n","\n","Please note that this question is just for illustrative purposes and filtering is not usually done this way - such sharp cutoffs introduce artifacts in the output.\n","\n","The input is a `M` length signal `x`, sampling frequency is `fs` and the FFT size `N`. The output is the filtered signal."]},{"cell_type":"code","execution_count":null,"metadata":{"id":"zmkDACeLauxw"},"outputs":[],"source":["# E3 - 3.1: Complete the function suppress_freq_dft_model()\n","\n","def suppress_freq_dft_model(x, fs, N):\n","    \"\"\"\n","    Args:\n","        x (np.array): input signal of length M (odd size)\n","        fs (float): sampling frequency (Hz)\n","        N (int): FFT size\n","\n","    Returns:\n","       np.array: output signal with filtering (N samples long)\n","    \"\"\"\n","    M = len(x)\n","    w = get_window('hamming', M)\n","    outputScaleFactor = sum(w)\n","\n","    ### Your code here\n"]},{"cell_type":"markdown","metadata":{"id":"gdZxyKJcauxw"},"source":["Test case for the function `suppress_freq_dft_model()`:\n","\n","_Test case 1:_ For an input signal with 40Hz, 100Hz, 200Hz, 1000Hz components, the output should only contain 100Hz, 200Hz and 1000Hz components.\n","\n","_Test case 2:_ For an input signal with 23Hz, 36Hz, 230Hz, 900Hz, 2300Hz components, the output should only contain 230Hz, 900Hz and 2300Hz components.\n","\n","To understand the effect of filtering, you can plot the magnitude spectra of the input and output signals superposed."]},{"cell_type":"code","execution_count":null,"metadata":{"id":"uBGhXtHtauxw"},"outputs":[],"source":["# E3 - 3.2: Compute the input signals proposed above and plot their magnitude spectra (x-axis in Hz),\n","# call the function suppress_freq_dft_model(), and plot the magnitude spectra of the output signals\n","\n","### Your code here\n"]},{"cell_type":"markdown","metadata":{"id":"gpY-Hj66auxw"},"source":["## Part 4 - Window-size, FFT-size, and zero-padding\n","\n","The function `zp_fft_size_expt()` should take an input signal, compute three different magnitude spectra (with different parameters) and return them.\n","\n","This function should provide some insights into the effects window-size, FFT-size, and zero-padding on the spectrum of a signal.\n","\n","The input signal should be of size 512 samples, the sampling rate should be 1000Hz, and the analysis window used should be hamming. The three set of analysis parameters should be:\n","\n","1. window-size = 256, FFT-size = 256 (no zero-padding)\n","2. window-size = 512, FFT-size = 512 (no zero-padding)\n","2. window-size = 256, FFT-size = 512 (zero-padding of 256 samples)\n","\n","Use `dftAnal()` to obtain the positive half of the magnitude spectrum (in dB). Return the 3 magnitude spectra in dB.\n"]},{"cell_type":"code","execution_count":null,"metadata":{"id":"K_pY6Tk7auxw"},"outputs":[],"source":["# E3 - 4.1: Complete the function zp_fft_size_expt()\n","\n","def zp_fft_size_expt(x, window_size=[256, 512, 256], FFT_size=[256, 512, 512]):\n","    \"\"\"compute magnitude spectra of x with different window sizes and FFT sizes.\n","\n","    Args:\n","        x (np.array): input signal (512 samples long)\n","\n","    Returns:\n","        list with magnitude spectra (np.array)\n","    \"\"\"\n","\n","    ### Your code here\n"]},{"cell_type":"markdown","metadata":{"id":"yXPciFyGauxw"},"source":["Test cases for the function `zp_fft_size_expt()`:\n","\n","_Test case 1:_ Use as input `x = .2*np.cos(2*np.pi*200*n)+.2*np.cos(2*np.pi*400*n)` where `n=np.arange(512)/fs` and the sampling rate `fs=1000`. Use the default arguments for `window_size` and `FFT_size`. Call the function with `mag_spectra = zp_fft_size_expt(x)`\n","\n","To understand better, plot the output of `dftAnal()` for each case on a common frequency axis with different colors. You will see that `mag_spectra[2]` is the interpolated version of `mag_spectra[0]` (zero-padding leads to interpolation of the DFT). You will also observe that the 'mainlobe' of the magnitude spectrum in `mag_spectra[1]` will be narrower than that in `mag_spectra[0]` and `mag_spectra[2]`. This shows that having a longer window leads to a narrower mainlobe with better frequency resolution and less spreading of the energy of the sinusoid."]},{"cell_type":"code","execution_count":null,"metadata":{"id":"DdRoDRf7auxw"},"outputs":[],"source":["# E3 - 4.2: Compute, plot, and play the input signal proposed above, call the function zp_fft_size_expt(), and plot\n","# the outputs\n","\n","### Your code here\n"]},{"cell_type":"markdown","metadata":{"id":"-KB9-SNSbdPM"},"source":["**Questions:**\n","E3 - 4.3: Explain the results of Part 4. If we were to estimate the frequency of the sinusoid using its DFT, a first principles approach is to choose the frequency value of the bin corresponding to the maximum in the DFT magnitude spectrum. If you were to take this approach, which of the magnitude spectra will give you a better estimate of the frequency of the sinusoid? Comment and discuss."]}],"metadata":{"colab":{"provenance":[]},"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.12.1"}},"nbformat":4,"nbformat_minor":0}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PPxSP-t3auxr"
+   },
+   "source": [
+    "# Exercise 3: Fourier properties\n",
+    "\n",
+    "With this exercise you will get a better understanding of some of the Fourier theorems and of some useful properties of the DFT. You will write code to implement and verify several properties of the DFT that are discussed in the lectures. You will also learn to use the `dftModel.py` module of sms-tools, which contains the basic python functions implementing the DFT. There are five parts in the exercise: 1) Minimize energy spread in DFT of sinusoids, 2) Symmetry properties of the DFT, 3) Suppressing frequency components using DFT model, and 4) FFT size and zero-padding.\n",
+    "\n",
+    "### Relevant Concepts\n",
+    "\n",
+    "__DFT of sinusoids:__ When a real sinusoid has an integer number of cycles in $N$ samples, the frequency of the sinusoid exactly matches one of the bin frequencies in an $N$ point DFT. Hence the DFT spectrum of the sinusoid has a value of zero at every DFT bin except at the two bins that match the frequency of the sinusoid. Otherwise, the energy of the sinusoid is spread over all the bins. When there are multiple sinusoids, the equations extend to each sinusoid.\n",
+    "\n",
+    "\\begin{align}\n",
+    " x[n]&=&A_{0}\\cos\\left(2\\pi k_{0}n/N\\right)=\\frac{A_{0}}{2}{\\textstyle e}^{j2\\pi k_{0}n/N}+\\frac{A_{0}}{2}{\\textstyle e}^{-j2\\pi k_{0}n/N}\\\\\n",
+    " X[k] &=& \\frac{A_0}{2} \\,\\,\\, \\mathrm{for} \\,\\,\\, k = k_0, -k_0; \\,\\,\\,\\, 0 \\,\\,\\,\\mathrm{otherwise}\n",
+    "\\end{align}\n",
+    "\n",
+    "__Zero-padding:__ Zero-padding a signal is done by adding zeros at the end of the signal. If we perform zero-padding to a signal before computing its DFT, the resulting spectrum will be an interpolated version of the spectrum of the original signal.  In most implementations of the DFT (including the FFT algorithms) when the DFT size is larger than the length of the signal, zero-padding is implicitly done.\n",
+    "\n",
+    "__Zero phase windowing:__ Zero phase windowing of a frame of a signal puts the centre of the signal at the zero time index for DFT computation. By moving the centre of the frame to zero index by a circular shift, the computed DFT will not have the phase offset which would have otherwise been introduced (recall that a shift of the signal causes the DFT to be multiplied by a complex exponential, which keeps the magnitude spectrum intact but changes the phase spectrum). When used in conjunction with zero-padding, zero phase windowing is also useful for the creation of a frame of length of power of 2 for FFT computation (`fftbuffer`).\n",
+    "\n",
+    "If the length of the signal $x$ is $M$ and the required DFT size is $N$, the zero phase windowed version of the signal, `dftbuffer`, for DFT computation can be obtained by (works for both even and odd $M$):\n",
+    "\n",
+    "    hM1 = floor((M+1)/2)\n",
+    "    hM2 = floor(M/2)\n",
+    "    dftbuffer = zeros(N)\n",
+    "    dftbuffer[:hM1] = x[hM2:]\n",
+    "    dftbuffer[-hM2:] = x[:hM2]\n",
+    "\n",
+    "__Real, even and odd signals:__ A signal is real when it does not have any imaginary component, and all sounds are real signals. A signal $x$ is even if $x[n] = x[-n]$, and odd if $x[n] = -x[-n]$. For a signal of length $M$ (and $M$ is odd), in the context of a zero phase windowed signal and its DFT, the signal is even if $x[n] = x[M-n]$ and odd if $x[n] = -x[M-n]$, $1 \\leq n \\leq M-1$. The DFT properties show that for real input signals, the magnitude spectrum is even and the phase spectrum is odd. Furthermore, when the input signal is both real and even, the DFT is real valued, with an even magnitude spectrum and imaginary component equal to zero. In summary, if $x$ is an input signal of length $M$ ($M$ is odd) and $X = \\mathrm{DFT}(x,M)$, then for $1 \\leq k \\leq M-1$\n",
+    "\n",
+    "If $x$ is real, $\\left|X[k]\\right| = \\left|X[M-k]\\right|$ and $\\boldsymbol{<}\\!X[k] = -\\boldsymbol{<}\\!X[M-k]$\n",
+    "\n",
+    "If $x$ is real and even, $\\left|X[k]\\right| = \\left|X[M-k]\\right|$ and $\\mathrm{imag}(X[k]) = 0$\n",
+    "\n",
+    "\n",
+    "__Positive half of the DFT spectrum:__ Audio signals are real signals. Due to the symmetry properties of the DFT of a real signal, it is sufficient to store only one half of the magnitude and phase spectra. To save on both storage and computation, we will just store just the half spectrum when possible.\n",
+    "\n",
+    "From an $N$ point DFT ($N$ even), we can obtain the positive half of the spectrum by considering only the first $(N/2)+1$ samples of the DFT. We can compute the magnitude spectrum of the positive half (in dB) as $m_X = 20\\log_{10}\\left|X[0:(N/2)+1]\\right|$, where $X$ is the DFT of the input.\n",
+    "\n",
+    "__Filtering:__ Filtering involves selectively suppressing certain frequencies present in the signal. Filtering is often performed in the time domain by the convolution of the input signal with the impulse response of a filter. The same operation can also be done in the DFT domain using the properties of DFT, by multiplying the DFT of the input signal by the DFT of the impulse response of the filter. In this assignment, we will consider a very simple illustrative filter that suppresses some frequency components by setting some DFT coefficients to zero. It is to be noted that the convolution operation here is circular convolution with a period $N$, the size of the DFT.\n",
+    "\n",
+    "If $x_1[n] \\Leftrightarrow X_1[k]$ and $x_2[n] \\Leftrightarrow X_2[k]$, $x_1[n] * x_2[n] \\Longleftrightarrow X_1[k]\\,X_2[k]$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZYIM_h_sauxt"
+   },
+   "source": [
+    "\n",
+    "## Part 1 - Minimize energy spread in DFT of sinusoids\n",
+    "\n",
+    "Given an input signal consisting of two sinusoids, the function `minimize_energy_spread_dft()` should select the first `M` samples from the signal and return the positive half of the DFT magnitude spectrum (in dB), such that it has only two non-zero values.\n",
+    "\n",
+    "`M` is to be calculated as the smallest positive integer for which the positive half of the DFT magnitude spectrum has only two non-zero values. To get the positive half of the spectrum, first compute the `M` point DFT of the input signal (for this you can use the `fft()` function of `scipy.fftpack`). Consider only the first `(M/2)+1` samples of the DFT, computing the magnitude spectrum of the positive half (in dB) as `mX = 20*log10(abs(X[:M/2+1]))`, where `X` is the DFT of the input signal.\n",
+    "\n",
+    "The input arguments to this function are the input signal `x` (of length W >= M) consisting of two sinusoids of frequency `f1` and `f2`, the sampling frequency `fs` and the value of frequencies `f1` and `f2`. The function should return the positive half of the magnitude spectrum `mX`. For this question, you can assume the input frequencies `f1` and `f2` to be positive integers and factors of `fs`, and that `M` is even.\n",
+    "\n",
+    "Due to the precision of the FFT computation, the zero values of the DFT are not zero but very small values < 1e-12 (or -240 dB) in magnitude. For practical purposes, all values with absolute value less than 1e-6 (or -120 dB) can be considered to be zero.\n",
+    "\n",
+    "HINT: The DFT magnitude spectrum of a sinusoid has only one non-zero value (in the positive half of the DFT spectrum) when its frequency coincides with one of the DFT bin frequencies. This happens when the DFT size (`M` in this question) contains exactly an integer number of periods of the sinusoid. Since the signal in this question consists of two sinusoids, this condition should hold true for each of the sinusoids, so that the DFT magnitude spectrum has only two non-zero values, one per sinusoid.\n",
+    "\n",
+    "`M` can be computed as the Least Common Multiple (LCM) of the sinusoid periods (in samples). The LCM of two numbers `x`, `y` can be computed as: `x*y/gcd(x,y)`, where gcd denotes the greatest common divisor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "9oEQLgLNauxu"
+   },
+   "source": [
+    "from scipy.fftpack import fft, fftshift\n",
+    "import numpy as np\n",
+    "from math import gcd, ceil, floor\n",
+    "from smstools.models.dftModel import dftAnal, dftSynth\n",
+    "from scipy.signal import get_window\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "ZQZwE69Pauxu"
+   },
+   "source": [
+    "def minimize_energy_spread_dft(x, fs, f1, f2):\n",
+    "    \"\"\" From a signal with two sinusoids compute its magnitude spectrum having only two non-zero value.\n",
+    "\n",
+    "    Args:\n",
+    "        x (np.array): input signal\n",
+    "        fs (float): sampling frequency in Hz\n",
+    "        f1 (float): frequency of first sinusoid component in Hz\n",
+    "        f2 (float): frequency of second sinusoid component in Hz\n",
+    "\n",
+    "    Returns:\n",
+    "        np.array: positive half of magnitude spectrum (in dB)\n",
+    "\n",
+    "    \"\"\"\n",
+    "    T1 = fs / f1\n",
+    "    T2 = fs / f2\n",
+    "    M = int(T1 * T2 / gcd(int(T1), int(T2)))\n",
+    "    X = fft(x[:M])\n",
+    "    mX = 20 * np.log10(np.abs(X[:M // 2 + 1]))\n",
+    "    return mX"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gV9H1iw6auxv"
+   },
+   "source": [
+    "Test cases for `minimize_energy_spread_dft()`:\n",
+    "\n",
+    "_Test case 1:_ For an input signal `x` sampled at `fs = 10000`Hz that consists of sinusoids of frequencies `f1 = 80`Hz and `f2 = 200`Hz, you need to select `M = 250` samples of the signal to meet the required condition. In this case, output `mX` is 126 samples in length and has non-zero values at bin indices 2 and 5 (corresponding to the frequency values of 80 and 200 Hz, respectively). You can create a test signal `x` by generating and adding two sinusoids of the given frequencies.\n",
+    "\n",
+    "_Test case 2:_ For an input signal `x` sampled at `fs = 48000` Hz that consists of sinusoids of frequencies `f1 = 300`Hz and `f2 = 800`Hz, you need to select `M = 480` samples of the signal to meet the required condition. In this case, output `mX` is 241 samples in length and has non-zero values at bin indices 3 and 8 (corresponding to the frequency values of 300 and 800 Hz, respectively). You can create a test signal `x` by generating and adding two sinusoids of the given frequencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "BG4EIZGiauxv"
+   },
+   "source": [
+    "fs = 10000\n",
+    "f1 = 80\n",
+    "f2 = 200\n",
+    "n = np.arange(0, 1, 1 / fs)\n",
+    "x = np.cos(2 * np.pi * f1 * n) + np.cos(2 * np.pi * f2 * n)\n",
+    "mX = minimize_energy_spread_dft(x, fs, f1, f2)\n",
+    "plt.plot(mX)\n",
+    "plt.title('Magnitude Spectrum')\n",
+    "plt.xlabel('Frequency (Hz)')\n",
+    "plt.ylabel('Magnitude (dB)')\n",
+    "plt.show()\n",
+    "\n",
+    "fs = 48000\n",
+    "f1 = 300\n",
+    "f2 = 800\n",
+    "n = np.arange(0, 1, 1 / fs)\n",
+    "x = np.cos(2 * np.pi * f1 * n) + np.cos(2 * np.pi * f2 * n)\n",
+    "mX = minimize_energy_spread_dft(x, fs, f1, f2)\n",
+    "plt.plot(mX)\n",
+    "plt.title('Magnitude Spectrum')\n",
+    "plt.xlabel('Frequency (Hz)')\n",
+    "plt.ylabel('Magnitude (dB)')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "E8dfWb-pauxv"
+   },
+   "source": [
+    "## Part 2 - Symmetry properties of the DFT\n",
+    "\n",
+    "The function `test_real_even()` should check if the input signal is real and even using the symmetry properties of its DFT. The function will return the result of this test, the zero-phase windowed version of the input signal (`dftbuffer`), and its DFT.\n",
+    "\n",
+    "Given an input signal `x` of length `M`, do a zero phase windowing of `x` without any zero-padding. Then compute the `M` point DFT of the zero phase windowed signal and use the symmetry of the computed DFT to test if the input signal `x` is real and even. Return the result of the test, the `dftbuffer` computed, and the DFT of the `dftbuffer`.\n",
+    "\n",
+    "The input argument is a signal `x` of length `M`. The output is a tuple with three elements\n",
+    "`(isRealEven, dftbuffer, X)`, where `isRealEven` is a boolean variable which is `True` if `x` is real and even, else `False`. `dftbuffer` is the `M` length zero phase windowed version of `x`. `X` is the `M` point DFT of the `dftbuffer`.\n",
+    "\n",
+    "To make the problem easier, we will use odd length input sequence in this question (`M` is odd).\n",
+    "\n",
+    "Due to the precision of the FFT computation, the zero values of the DFT are not zero but very small values < 1e-12 in magnitude. For practical purposes, all values with absolute value less than 1e-6 can be considered to be zero. Use an error tolerance of 1e-6 to compare if two floating point arrays are equal.\n",
+    "\n",
+    "Caveat: Use the imaginary part of the spectrum instead of the phase to check if the input signal is real and even."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "WW6d_8Wxauxv"
+   },
+   "source": [
+    "def test_real_even(x):\n",
+    "    \"\"\"check if x is real and even using the symmetry properties of its DFT.\n",
+    "    Args:\n",
+    "        x (np.array): input signal of length M (M is odd)\n",
+    "\n",
+    "    Returns:\n",
+    "        tuple including:\n",
+    "        isRealEven (boolean): True if input x is real and even, and False otherwise\n",
+    "        dftbuffer (np.array): M point zero phase windowed version of x\n",
+    "        X (np.array): M point DFT of dftbuffer\n",
+    "\n",
+    "    \"\"\"\n",
+    "    M = len(x)\n",
+    "    hM1 = floor((M + 1) / 2)\n",
+    "    hM2 = floor(M / 2)\n",
+    "    dftbuffer = np.zeros(M)\n",
+    "    dftbuffer[:hM1] = x[hM2:]\n",
+    "    dftbuffer[-hM2:] = x[:hM2]\n",
+    "    X = fft(dftbuffer)\n",
+    "    isRealEven = np.allclose(X.imag, 0, atol=1e-6)\n",
+    "    return isRealEven, dftbuffer, X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "W7rW2dmHauxv"
+   },
+   "source": [
+    "Test cases for `test_real_even()`:\n",
+    "\n",
+    "_Test case 1:_ If `x = np.array([2, 3, 4, 3, 2])`, which is a real and even signal (after zero phase windowing), the function returns\n",
+    "\n",
+    "```\n",
+    "(True, array([ 4., 3., 2., 2., 3.]), array([14.0000+0.j, 2.6180+0.j,\n",
+    "0.3820+0.j, 0.3820+0.j, 2.6180+0.j])) (values are approximate)\n",
+    "```\n",
+    "\n",
+    "_Test case 2:_ If `x = np.array([1, 2, 3, 4, 1, 2, 3])`, which is not an even signal (after zero phase windowing), the function returns\n",
+    "\n",
+    "```\n",
+    "(False,  array([ 4.,  1.,  2.,  3.,  1.,  2.,  3.]), array([ 16.+0.j,\n",
+    "2.+0.69j, 2.+3.51j, 2.-1.08j, 2.+1.08j, 2.-3.51j, 2.-0.69j])) (values are approximate)\n",
+    "```\n",
+    "\n",
+    "To get a more realistic example use a longer input signal and plot the real and imaginary parts of the output spectrum `X`. For example, use `x = get_window('hanning', 51, fftbins=False)`, which is real an even, and plot `x`and the real and imaginary part of the spectrum `X`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "BdsmJiexauxv"
+   },
+   "source": [
+    "x = np.array([2, 3, 4, 3, 2])\n",
+    "isRealEven, dftbuffer, X = test_real_even(x)\n",
+    "print(isRealEven)\n",
+    "print(dftbuffer)\n",
+    "print(X)\n",
+    "\n",
+    "x = get_window('hanning', 51, fftbins=False)\n",
+    "isRealEven, dftbuffer, X = test_real_even(x)\n",
+    "plt.plot(x)\n",
+    "plt.title('Input Signal')\n",
+    "plt.xlabel('Sample')\n",
+    "plt.ylabel('Amplitude')\n",
+    "plt.show()\n",
+    "plt.plot(X.real)\n",
+    "plt.title('Real Part of Spectrum')\n",
+    "plt.xlabel('Frequency Bin')\n",
+    "plt.ylabel('Amplitude')\n",
+    "plt.show()\n",
+    "plt.plot(X.imag)\n",
+    "plt.title('Imaginary Part of Spectrum')\n",
+    "plt.xlabel('Frequency Bin')\n",
+    "plt.ylabel('Amplitude')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tzReXqw4auxw"
+   },
+   "source": [
+    "## Part 3 - Suppressing frequency components using DFT model\n",
+    "\n",
+    "Given a signal as input, the function `supress_freq_dft_model()` should suppress the frequency components <= 70Hz using the DFT. It should return the filtered signal in the time domain.\n",
+    "\n",
+    "Use the DFT to implement a very basic form of frequency domain filtering. Use the functions `dftAnal()` and `dftSynth()` provided in the `dftModel.py` module.\n",
+    "\n",
+    "Use `dftAnal()` to obtain the magnitude spectrum (in dB) and phase spectrum of the audio signal. Set the values of the magnitude spectrum that correspond to frequencies <= 70 Hz to -120dB (there may not be a bin corresponding exactly to 70Hz, choose the nearest bin of equal or higher frequency, e.g., using `np.ceil()`).\n",
+    "\n",
+    "Use `dftSynth()` to synthesize the filtered output signal. Then return the filtered signal.\n",
+    "\n",
+    "Use a hamming window to smooth the signal. Hence, do not forget to scale the output signals by the sum of the window values (as done in `software/models_interface/dftModel_function.py`).  \n",
+    "\n",
+    "Please note that this question is just for illustrative purposes and filtering is not usually done this way - such sharp cutoffs introduce artifacts in the output.\n",
+    "\n",
+    "The input is a `M` length signal `x`, sampling frequency is `fs` and the FFT size `N`. The output is the filtered signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "zmkDACeLauxw"
+   },
+   "source": [
+    "def suppress_freq_dft_model(x, fs, N):\n",
+    "    \"\"\"\n",
+    "    Args:\n",
+    "        x (np.array): input signal of length M (odd size)\n",
+    "        fs (float): sampling frequency (Hz)\n",
+    "        N (int): FFT size\n",
+    "\n",
+    "    Returns:\n",
+    "       np.array: output signal with filtering (N samples long)\n",
+    "    \"\"\"\n",
+    "    M = len(x)\n",
+    "    w = get_window('hamming', M)\n",
+    "    outputScaleFactor = sum(w)\n",
+    "    mX, pX = dftAnal(x, w, N)\n",
+    "    cutoff_bin = int(np.ceil(70 * N / fs))\n",
+    "    mX[:cutoff_bin] = -120\n",
+    "    y = dftSynth(mX, pX, M) * outputScaleFactor\n",
+    "    return y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gdZxyKJcauxw"
+   },
+   "source": [
+    "Test case for the function `suppress_freq_dft_model()`:\n",
+    "\n",
+    "_Test case 1:_ For an input signal with 40Hz, 100Hz, 200Hz, 1000Hz components, the output should only contain 100Hz, 200Hz and 1000Hz components.\n",
+    "\n",
+    "_Test case 2:_ For an input signal with 23Hz, 36Hz, 230Hz, 900Hz, 2300Hz components, the output should only contain 230Hz, 900Hz and 2300Hz components.\n",
+    "\n",
+    "To understand the effect of filtering, you can plot the magnitude spectra of the input and output signals superposed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "uBGhXtHtauxw"
+   },
+   "source": [
+    "fs = 1000\n",
+    "N = 1024\n",
+    "n = np.arange(0, 1, 1 / fs)\n",
+    "x = np.cos(2 * np.pi * 40 * n) + np.cos(2 * np.pi * 100 * n) + np.cos(2 * np.pi * 200 * n) + np.cos(2 * np.pi * 1000 * n)\n",
+    "y = suppress_freq_dft_model(x, fs, N)\n",
+    "mX, _ = dftAnal(x, get_window('hamming', len(x)), N)\n",
+    "mY, _ = dftAnal(y, get_window('hamming', len(y)), N)\n",
+    "plt.plot(mX, label='Input')\n",
+    "plt.plot(mY, label='Output')\n",
+    "plt.title('Magnitude Spectrum')\n",
+    "plt.xlabel('Frequency (Hz)')\n",
+    "plt.ylabel('Magnitude (dB)')\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "x = np.cos(2 * np.pi * 23 * n) + np.cos(2 * np.pi * 36 * n) + np.cos(2 * np.pi * 230 * n) + np.cos(2 * np.pi * 900 * n) + np.cos(2 * np.pi * 2300 * n)\n",
+    "y = suppress_freq_dft_model(x, fs, N)\n",
+    "mX, _ = dftAnal(x, get_window('hamming', len(x)), N)\n",
+    "mY, _ = dftAnal(y, get_window('hamming', len(y)), N)\n",
+    "plt.plot(mX, label='Input')\n",
+    "plt.plot(mY, label='Output')\n",
+    "plt.title('Magnitude Spectrum')\n",
+    "plt.xlabel('Frequency (Hz)')\n",
+    "plt.ylabel('Magnitude (dB)')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gpY-Hj66auxw"
+   },
+   "source": [
+    "## Part 4 - Window-size, FFT-size, and zero-padding\n",
+    "\n",
+    "The function `zp_fft_size_expt()` should take an input signal, compute three different magnitude spectra (with different parameters) and return them.\n",
+    "\n",
+    "This function should provide some insights into the effects window-size, FFT-size, and zero-padding on the spectrum of a signal.\n",
+    "\n",
+    "The input signal should be of size 512 samples, the sampling rate should be 1000Hz, and the analysis window used should be hamming. The three set of analysis parameters should be:\n",
+    "\n",
+    "1. window-size = 256, FFT-size = 256 (no zero-padding)\n",
+    "2. window-size = 512, FFT-size = 512 (no zero-padding)\n",
+    "2. window-size = 256, FFT-size = 512 (zero-padding of 256 samples)\n",
+    "\n",
+    "Use `dftAnal()` to obtain the positive half of the magnitude spectrum (in dB). Return the 3 magnitude spectra in dB.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "K_pY6Tk7auxw"
+   },
+   "source": [
+    "def zp_fft_size_expt(x, window_size=[256, 512, 256], FFT_size=[256, 512, 512]):\n",
+    "    \"\"\"compute magnitude spectra of x with different window sizes and FFT sizes.\n",
+    "\n",
+    "    Args:\n",
+    "        x (np.array): input signal (512 samples long)\n",
+    "\n",
+    "    Returns:\n",
+    "        list with magnitude spectra (np.array)\n",
+    "    \"\"\"\n",
+    "    mag_spectra = []\n",
+    "    for ws, fs in zip(window_size, FFT_size):\n",
+    "        w = get_window('hamming', ws)\n",
+    "        mX, _ = dftAnal(x[:ws], w, fs)\n",
+    "        mag_spectra.append(mX)\n",
+    "    return mag_spectra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yXPciFyGauxw"
+   },
+   "source": [
+    "Test cases for the function `zp_fft_size_expt()`:\n",
+    "\n",
+    "_Test case 1:_ Use as input `x = .2*np.cos(2*np.pi*200*n)+.2*np.cos(2*np.pi*400*n)` where `n=np.arange(512)/fs` and the sampling rate `fs=1000`. Use the default arguments for `window_size` and `FFT_size`. Call the function with `mag_spectra = zp_fft_size_expt(x)`\n",
+    "\n",
+    "To understand better, plot the output of `dftAnal()` for each case on a common frequency axis with different colors. You will see that `mag_spectra[2]` is the interpolated version of `mag_spectra[0]` (zero-padding leads to interpolation of the DFT). You will also observe that the 'mainlobe' of the magnitude spectrum in `mag_spectra[1]` will be narrower than that in `mag_spectra[0]` and `mag_spectra[2]`. This shows that having a longer window leads to a narrower mainlobe with better frequency resolution and less spreading of the energy of the sinusoid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "DdRoDRf7auxw"
+   },
+   "source": [
+    "fs = 1000\n",
+    "n = np.arange(512) / fs\n",
+    "x = 0.2 * np.cos(2 * np.pi * 200 * n) + 0.2 * np.cos(2 * np.pi * 400 * n)\n",
+    "mag_spectra = zp_fft_size_expt(x)\n",
+    "for i, mX in enumerate(mag_spectra):\n",
+    "    plt.plot(mX, label=f'Spectrum {i + 1}')\n",
+    "plt.title('Magnitude Spectra')\n",
+    "plt.xlabel('Frequency (Hz)')\n",
+    "plt.ylabel('Magnitude (dB)')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-KB9-SNSbdPM"
+   },
+   "source": [
+    "**Questions:**\n",
+    "E3 - 4.3: Explain the results of Part 4. If we were to estimate the frequency of the sinusoid using its DFT, a first principles approach is to choose the frequency value of the bin corresponding to the maximum in the DFT magnitude spectrum. If you were to take this approach, which of the magnitude spectra will give you a better estimate of the frequency of the sinusoid? Comment and discuss."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Complete the functions in `exercises/E3-Fourier-properties.ipynb` to address the tasks in Exercise 3.

* **Minimize energy spread in DFT of sinusoids**: Implement `minimize_energy_spread_dft` to select the first `M` samples from the signal and return the positive half of the DFT magnitude spectrum (in dB).
* **Symmetry properties of the DFT**: Implement `test_real_even` to check if the input signal is real and even using the symmetry properties of its DFT.
* **Suppressing frequency components using DFT model**: Implement `suppress_freq_dft_model` to suppress the frequency components <= 70Hz using the DFT.
* **Window-size, FFT-size, and zero-padding**: Implement `zp_fft_size_expt` to compute three different magnitude spectra (with different parameters) and return them.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pepalonso/sms-exercises/pull/1?shareId=ac490843-dd1c-4f1b-b6aa-dec7cd912915).